### PR TITLE
chore: use id addresses

### DIFF
--- a/actors/adm/src/ext.rs
+++ b/actors/adm/src/ext.rs
@@ -42,7 +42,7 @@ pub mod machine {
 
     #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
     pub struct ConstructorParams {
-        /// The machine owner robust address.
+        /// The machine owner ID address.
         pub owner: Address,
         /// User-defined metadata.
         pub metadata: HashMap<String, String>,
@@ -50,7 +50,7 @@ pub mod machine {
 
     #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
     pub struct InitParams {
-        /// The machine reorg safe address.
-        pub robust_address: Address,
+        /// The machine ID address.
+        pub address: Address,
     }
 }

--- a/actors/adm/src/state.rs
+++ b/actors/adm/src/state.rs
@@ -97,7 +97,7 @@ impl Display for Kind {
 pub struct Metadata {
     /// Machine kind.
     pub kind: Kind,
-    /// Machine robust address.
+    /// Machine ID address.
     pub address: Address,
     /// User-defined data.
     pub metadata: HashMap<String, String>,
@@ -110,7 +110,7 @@ pub struct State {
     /// This is fixed at genesis.
     pub machine_codes: Cid,
     /// The permission mode controlling who can create machines.
-    /// The is fixed at genesis, but in allowlist mode, the set of deployers can be changed
+    /// This is fixed at genesis, but in allowlist mode, the set of deployers can be changed
     /// by any member.
     /// Modeled after the IPC EAM actor.
     pub permission_mode: PermissionMode,


### PR DESCRIPTION
Moves the ADM actor to deal in ID type addresses, not "external" addresses. ID addresses can be represented in normal Ethereum hex style.